### PR TITLE
ci: Do not sign commit and tag on `npm version`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-sign-git-tag = true


### PR DESCRIPTION
PGP is bad and dead. Do not sign.

Closes #47