### PR TITLE
ci: Remove body and footer length constraints from commitlint config

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,9 +1,7 @@
 {
     "rules": {
         "body-leading-blank": [2, "always"],
-        "body-max-line-length": [2, "always", 72],
         "footer-leading-blank": [2, "always"],
-        "footer-max-line-length": [2, "always", 72],
         "header-full-stop": [2, "never", "."],
         "header-max-length": [2, "always", 72],
         "references-empty": [1, "never"],


### PR DESCRIPTION
Closes #70.