### PR TITLE
Release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="2.2.0"></a>
+# [2.2.0](https://github.com/Diplomatiq/crypto-random/compare/v2.1.0...v2.2.0) (2020-03-14)
+
+
+### SECURITY BULLETIN
+
+* bump acorn from 7.1.0 to 7.1.1 ([7e5a426](https://github.com/Diplomatiq/crypto-random/commit/7e5a426))
+
+
 <a name="2.1.0"></a>
 # [2.1.0](https://github.com/Diplomatiq/crypto-random/compare/v2.0.0...v2.1.0) (2020-02-13)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@diplomatiq/crypto-random",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diplomatiq/crypto-random",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Generate cryptographically strong, uniformly distributed random integers from custom intervals, strings from custom character sets, and boolean values.",
   "main": "dist/main.js",
   "module": "dist/main.js",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Standard properties
 sonar.projectKey=Diplomatiq_crypto-random
 sonar.projectName=crypto-random
-sonar.projectVersion=2.1.0
+sonar.projectVersion=2.2.0
 
 sonar.sources=src
 sonar.tests=test


### PR DESCRIPTION
<a name="2.2.0"></a>
# [2.2.0](https://github.com/Diplomatiq/crypto-random/compare/v2.1.0...v2.2.0) (2020-03-14)


### SECURITY BULLETIN

* bump acorn from 7.1.0 to 7.1.1 ([7e5a426](https://github.com/Diplomatiq/crypto-random/commit/7e5a426))